### PR TITLE
allow key to be big (bigger than block size)

### DIFF
--- a/HMACSHA256.sql
+++ b/HMACSHA256.sql
@@ -21,9 +21,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 DROP FUNCTION IF EXISTS HMACSHA256;
 
--- here email is the message generate a HMAC for
+-- here val is the message generate a HMAC for
 DELIMITER //
-CREATE FUNCTION HMACSHA256(secret_key VARCHAR(36), val VARCHAR(128))
+CREATE FUNCTION HMACSHA256(secret_key VARCHAR(256), val VARCHAR(2048))
   RETURNS CHAR(64) DETERMINISTIC
 BEGIN
 DECLARE ipad,opad BINARY(64);
@@ -32,7 +32,9 @@ DECLARE hmac CHAR(64);
 
 SET hexkey = RPAD(HEX(secret_key),128,"0");
 
-
+IF LENGTH(secret_key) > 64 THEN
+   SET hexkey = RPAD(SHA2(secret_key, '256'), 128, "0");
+END IF;
 
 SET ipad = UNHEX(CONCAT(
 LPAD(CONV(CONV( MID(hexkey,1  ,16), 16, 10 ) ^ CONV( '3636363636363636', 16, 10 ),10,16),16,"0"),


### PR DESCRIPTION
The original function only allows small keys.

This one let user provide bigger keys, even bigger than block size (and hash it as requested by rfc2104)